### PR TITLE
Fixed text encoding by using CP1252

### DIFF
--- a/src/irsdkSharp.Serialization/IRacingSDKExtensions.cs
+++ b/src/irsdkSharp.Serialization/IRacingSDKExtensions.cs
@@ -11,15 +11,14 @@ namespace irsdkSharp.Serialization
     {
         public static IRacingSessionModel GetSerializedSessionInfo(this IRacingSDK racingSDK)
         {
-            if (racingSDK.IsInitialized && racingSDK.Header != null)
-            {
-                byte[] data = new byte[racingSDK.Header.SessionInfoLength];
-                IRacingSDK.GetFileMapView(racingSDK).ReadArray(racingSDK.Header.SessionInfoOffset, data, 0, racingSDK.Header.SessionInfoLength);
+            var sessionInfo = racingSDK.GetSessionInfo();
 
-                //Serialise the string into objects, tada!
-                return IRacingSessionModel.Serialize(Encoding.Default.GetString(data).TrimEnd(new char[] { '\0' }));
+            if (sessionInfo == null)
+            {
+                return null;
             }
-            return null;
+
+            return IRacingSessionModel.Serialize(sessionInfo);
         }
 
         public static IRacingDataModel GetSerializedData(this IRacingSDK racingSDK)

--- a/src/irsdkSharp/iRacingSDK.cs
+++ b/src/irsdkSharp/iRacingSDK.cs
@@ -11,6 +11,8 @@ namespace irsdkSharp
 {
     public class IRacingSDK
     {
+        private Encoding encoding;
+
         //VarHeader offsets
         public const int VarOffsetOffset = 4;
         public const int VarCountOffset = 8;
@@ -33,6 +35,13 @@ namespace irsdkSharp
         public IRacingSdkHeader Header = null;
         public Dictionary<string, VarHeader> VarHeaders = new Dictionary<string, VarHeader>();
         //List<CVarHeader> VarHeaders = new List<CVarHeader>();
+
+        public IRacingSDK()
+        {
+            // Register CP1252 encoding
+            Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
+            encoding = Encoding.GetEncoding(1252);
+        }
 
         public bool Startup()
         {
@@ -69,9 +78,9 @@ namespace irsdkSharp
                 FileMapView.ReadArray<byte>(Header.VarHeaderOffset + ((i * VarHeader.Size) + VarNameOffset), name, 0, Constants.MaxString);
                 FileMapView.ReadArray<byte>(Header.VarHeaderOffset + ((i * VarHeader.Size) + VarDescOffset), desc, 0, Constants.MaxDesc);
                 FileMapView.ReadArray<byte>(Header.VarHeaderOffset + ((i * VarHeader.Size) + VarUnitOffset), unit, 0, Constants.MaxString);
-                string nameStr = Encoding.Default.GetString(name).TrimEnd(new char[] { '\0' });
-                string descStr = Encoding.Default.GetString(desc).TrimEnd(new char[] { '\0' });
-                string unitStr = Encoding.Default.GetString(unit).TrimEnd(new char[] { '\0' });
+                string nameStr = encoding.GetString(name).TrimEnd(new char[] { '\0' });
+                string descStr = encoding.GetString(desc).TrimEnd(new char[] { '\0' });
+                string unitStr = encoding.GetString(unit).TrimEnd(new char[] { '\0' });
                 VarHeaders[nameStr] = new VarHeader(type, offset, count, nameStr, descStr, unitStr);
             }
         }
@@ -88,7 +97,7 @@ namespace irsdkSharp
                     {
                         byte[] data = new byte[count];
                         FileMapView.ReadArray<byte>(Header.Buffer + varOffset, data, 0, count);
-                        return Encoding.Default.GetString(data).TrimEnd(new char[] { '\0' });
+                        return encoding.GetString(data).TrimEnd(new char[] { '\0' });
                     }
                     else if (VarHeaders[name].Type == VarType.irBool)
                     {
@@ -153,7 +162,7 @@ namespace irsdkSharp
             {
                 byte[] data = new byte[Header.SessionInfoLength];
                 FileMapView.ReadArray<byte>(Header.SessionInfoOffset, data, 0, Header.SessionInfoLength);
-                return Encoding.Default.GetString(data).TrimEnd(new char[] { '\0' });
+                return encoding.GetString(data).TrimEnd(new char[] { '\0' });
             }
             return null;
         }

--- a/src/irsdkSharp/irsdkSharp.csproj
+++ b/src/irsdkSharp/irsdkSharp.csproj
@@ -35,6 +35,10 @@
     </None>
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="System.Text.Encoding.CodePages" Version="5.0.0" />
+  </ItemGroup>
+
   <Target DependsOnTargets="ResolveReferences" Name="CopyProjectReferencesToPackage">
     <ItemGroup>
       <BuildOutputInPackage Include="@(ReferenceCopyLocalPaths-&gt;WithMetadataValue('ReferenceSourceTarget', 'ProjectReference'))" />


### PR DESCRIPTION
The text encoding was broken for most special characters since the wrong encoding is used in all .NET iRacing SDKs so far. Codepage 1252 must be used.

## Before

![Screenshot 2020-12-27 122057](https://user-images.githubusercontent.com/229567/103169676-36d47e80-483e-11eb-8517-3cd8c9195b13.png)

## After

![Screenshot 2020-12-27 122003](https://user-images.githubusercontent.com/229567/103169680-3936d880-483e-11eb-92ae-c22b926e7c85.png)