### PR TITLE
Adds CarClassEstLapTime property to DriverModel

### DIFF
--- a/src/irsdkSharp.Serialization/Models/Session/DriverInfo/DriverModel.cs
+++ b/src/irsdkSharp.Serialization/Models/Session/DriverInfo/DriverModel.cs
@@ -32,6 +32,7 @@ namespace irsdkSharp.Serialization.Models.Session.DriverInfo
         public string CarClassMaxFuelPct { get; set; }// %.3f %
         public string CarClassWeightPenalty { get; set; }// %.3f kg
         public string CarClassColor { get; set; }// 0x%02x%02x%02x
+        public float CarClassEstLapTime { get; set; }
         public int IRating { get; set; }// %d
         public int LicLevel { get; set; }// %d
         public int LicSubLevel { get; set; }// %d


### PR DESCRIPTION
When deserializing session data, an error regarding a missing property, "CarClassEstLapTime" is output to the console.

This PR adds the CarClassEstLapTime as a float property. Tested to deserialize properly (~53 seconds for TCR at Tsukuba).