### PR TITLE
Improved performance by only using one loop

### DIFF
--- a/src/irsdkSharp.Console/Program.cs
+++ b/src/irsdkSharp.Console/Program.cs
@@ -17,6 +17,15 @@ namespace irsdkSharp.ConsoleTest
             sdk.DataChanged += Sdk_OnDataChanged;
             sdk.Disconnected += Sdk_OnDisconnected;
             sdk.Connected += Sdk_OnConnected;
+            
+            sdk.Start();
+            Console.WriteLine("Started...");
+            
+            Console.ReadLine();
+            
+            sdk.Stop();
+            Console.WriteLine("Stopped...");
+            
             Console.ReadLine();
         }
 

--- a/src/irsdkSharp.Console/Program.cs
+++ b/src/irsdkSharp.Console/Program.cs
@@ -14,23 +14,23 @@ namespace irsdkSharp.ConsoleTest
         static void Main(string[] args)
         {
             sdk = new IRacingSDK();
-            sdk.OnDataChanged += Sdk_OnDataChanged;
-            sdk.OnDisconnected += Sdk_OnDisconnected;
-            sdk.OnConnected += Sdk_OnConnected;
+            sdk.DataChanged += Sdk_OnDataChanged;
+            sdk.Disconnected += Sdk_OnDisconnected;
+            sdk.Connected += Sdk_OnConnected;
             Console.ReadLine();
         }
 
-        private static void Sdk_OnConnected()
+        private static void Sdk_OnConnected(object sender, EventArgs eventArgs)
         {
             Console.WriteLine("Connected");
         }
 
-        private static void Sdk_OnDisconnected()
+        private static void Sdk_OnDisconnected(object sender, EventArgs eventArgs)
         {
             Console.WriteLine("Disconnected");
         }
 
-        private static void Sdk_OnDataChanged()
+        private static void Sdk_OnDataChanged(object sender, EventArgs eventArgs)
         {
             var currentlyConnected = sdk.IsConnected();
 

--- a/src/irsdkSharp.Serialization/IRacingSDKExtensions.cs
+++ b/src/irsdkSharp.Serialization/IRacingSDKExtensions.cs
@@ -30,11 +30,9 @@ namespace irsdkSharp.Serialization
         {
             if (racingSDK.IsConnected())
             {
-                var fileView = IRacingSDK.GetFileMapView(racingSDK);
-                var headers = IRacingSDK.GetVarHeaders(racingSDK);
                 var data = new byte[racingSDK.Header.BufferLength];
-                fileView.ReadArray(racingSDK.Header.Offset, data, 0, racingSDK.Header.BufferLength);
-                return IRacingDataModel.Serialize(data, headers);
+                racingSDK.FileMapView.ReadArray(racingSDK.Header.Offset, data, 0, racingSDK.Header.BufferLength);
+                return IRacingDataModel.Serialize(data, racingSDK.VarHeaders);
             }
             return null;
         }
@@ -100,12 +98,10 @@ namespace irsdkSharp.Serialization
         {
             if (racingSDK.IsConnected())
             {
-                var fileView = IRacingSDK.GetFileMapView(racingSDK);
-                var headers = IRacingSDK.GetVarHeaders(racingSDK);
                 var data = new byte[racingSDK.Header.BufferLength];
-                fileView.ReadArray(racingSDK.Header.Offset, data, 0, racingSDK.Header.BufferLength);
+                racingSDK.FileMapView.ReadArray(racingSDK.Header.Offset, data, 0, racingSDK.Header.BufferLength);
                 sessionTime = (double)racingSDK.GetData("SessionTime");
-                return IRacingDataModel.SerializeCars(data, headers);
+                return IRacingDataModel.SerializeCars(data, racingSDK.VarHeaders);
             }
             sessionTime = 0;
             return null;

--- a/src/irsdkSharp.Serialization/Models/Fastest/Data.cs
+++ b/src/irsdkSharp.Serialization/Models/Fastest/Data.cs
@@ -24,8 +24,8 @@ namespace irsdkSharp.Serialization.Models.Fastest
         public Data(IRacingSDK sdk)
         {
             _sdk = sdk;
-            _fileView = IRacingSDK.GetFileMapView(sdk);
-            _headers = IRacingSDK.GetVarHeaders(sdk);
+            _fileView = sdk.FileMapView;
+            _headers = sdk.VarHeaders;
         }
 
         //private IRacingSessionModel _session;

--- a/src/irsdkSharp/Constants.cs
+++ b/src/irsdkSharp/Constants.cs
@@ -13,5 +13,13 @@
         public const int MaxBufs = 4;
         public const int StatusConnected = 1;
         public const int SessionStringLength = 0x20000; // 128k
+        
+        public const int VarOffsetOffset = 4;
+        public const int VarCountOffset = 8;
+        public const int VarNameOffset = 16;
+        public const int VarDescOffset = 48;
+        public const int VarUnitOffset = 112;
+        
+        public const char EndChar = '\0';
     }
 }

--- a/src/irsdkSharp/Extensions/MemoryMappedViewAccessorExtensions.cs
+++ b/src/irsdkSharp/Extensions/MemoryMappedViewAccessorExtensions.cs
@@ -1,4 +1,5 @@
-﻿using System.IO.MemoryMappedFiles;
+﻿using System;
+using System.IO.MemoryMappedFiles;
 using System.Text;
 
 namespace irsdkSharp.Extensions
@@ -27,6 +28,14 @@ namespace irsdkSharp.Extensions
                 sb.Append(c);
             }
             return sb.ToString();
+        }
+        
+        public static T[] ReadArray<T>(this MemoryMappedViewAccessor accessor, int position, int count) 
+            where T : struct
+        {
+            var value = new T[count];
+            accessor.ReadArray(position, value, 0, count);
+            return value;
         }
     }
 }

--- a/src/irsdkSharp/IRacingSdkDefaults.cs
+++ b/src/irsdkSharp/IRacingSdkDefaults.cs
@@ -1,0 +1,22 @@
+﻿namespace irsdkSharp;
+
+/// <summary>
+/// The default values for the iRacing SDK
+/// </summary>
+public static class IRacingSdkDefaults
+{
+    /// <summary>
+    /// The default updates per second.
+    /// </summary>
+    public const int DefaultUpdateFrequency = 1;
+    
+    /// <summary>
+    /// The maximum updates per second supported by iRacing.
+    /// </summary>
+    public const int MaxUpdateFrequency = 60;
+    
+    /// <summary>
+    /// The default delay between a connection check when the sim is not connected.
+    /// </summary>
+    public const int DefaultCheckConnectionDelay = 5000;
+}

--- a/src/irsdkSharp/IRacingSdkOptions.cs
+++ b/src/irsdkSharp/IRacingSdkOptions.cs
@@ -1,0 +1,54 @@
+﻿using System;
+
+namespace irsdkSharp;
+
+/// <summary>
+/// Options for the iRacing SDK
+/// </summary>
+public class IRacingSdkOptions
+{
+    /// <summary>
+    /// The default sdk options.
+    /// </summary>
+    public static readonly IRacingSdkOptions Default = new();
+    
+    private int _updateFrequency = IRacingSdkDefaults.DefaultUpdateFrequency;
+    private int _checkConnectionDelay = IRacingSdkDefaults.DefaultCheckConnectionDelay;
+
+    /// <summary>
+    /// The actual delay between updates in milliseconds
+    /// </summary>
+    internal int UpdateDelay => 1000 / UpdateFrequency;
+    
+    /// <summary>
+    /// Updates per second (1-60)
+    /// </summary>
+    public int UpdateFrequency
+    {
+        get => _updateFrequency;
+        set
+        {
+            if (value <= 0 || value > IRacingSdkDefaults.MaxUpdateFrequency)
+                throw new ArgumentOutOfRangeException(nameof(value), 
+                    "The UpdateFrequency must be between 1 and 60");
+                
+            _updateFrequency = value;
+        }
+    }
+
+    /// <summary>
+    /// The delay between a connection check when the sim is not connected
+    /// </summary>
+    public int CheckConnectionDelay
+    {
+        get => _checkConnectionDelay;
+        set
+        {
+            if (value <= 0)
+                throw new ArgumentOutOfRangeException(nameof(value), 
+                    "The CheckConnectionDelay must be greater than 0");
+            
+            _checkConnectionDelay = value;
+        }
+    }
+}

--- a/src/irsdkSharp/Models/VarHeader.cs
+++ b/src/irsdkSharp/Models/VarHeader.cs
@@ -4,7 +4,7 @@ namespace irsdkSharp.Models
 {
     public class VarHeader
     {
-        public static int Size { get; } = 144;
+        public const int Size = 144;
 
         public VarHeader(int type, int offset, int count, string name, string desc, string unit)
         {
@@ -32,23 +32,26 @@ namespace irsdkSharp.Models
         {
             get
             {
-                if (Type == VarType.irChar || Type == VarType.irBool)
-                    return 1;
-                else if (Type == VarType.irInt || Type == VarType.irBitField || Type == VarType.irFloat)
-                    return 4;
-                else if (Type == VarType.irDouble)
-                    return 8;
-
-                return 0;
+                switch (Type)
+                {
+                    case VarType.irChar:
+                    case VarType.irBool:
+                        return 1;
+                    
+                    case VarType.irInt:
+                    case VarType.irBitField:
+                    case VarType.irFloat:
+                        return 4;
+                    
+                    case VarType.irDouble:
+                        return 8;
+                    
+                    default:
+                        return 0;
+                }
             }
         }
 
-        public int Length
-        {
-            get
-            {
-                return Bytes * Count;
-            }
-        }
+        public int Length => Count * Bytes;
     }
 }

--- a/src/irsdkSharp/iRacingSDK.cs
+++ b/src/irsdkSharp/iRacingSDK.cs
@@ -11,9 +11,11 @@ using Microsoft.Extensions.Logging;
 using System.Threading.Tasks;
 using irsdkSharp.Extensions;
 using System.IO;
+using System.Runtime.Versioning;
 
 namespace irsdkSharp
 {
+    [SupportedOSPlatform("windows")]
     public class IRacingSDK
     {
         #region Constants

--- a/src/irsdkSharp/iRacingSDK.cs
+++ b/src/irsdkSharp/iRacingSDK.cs
@@ -59,8 +59,19 @@ namespace irsdkSharp
         [Obsolete("Use the Disconnected event instead.", true)]
         public event Action OnDisconnected;
 
+        /// <summary>
+        /// Invoked every time the SDK reads the data from iRacing. Not necessarily new data.
+        /// </summary>
         public event EventHandler? DataChanged;
+        
+        /// <summary>
+        /// Invoked when the SDK starts receiving data from iRacing.
+        /// </summary>
         public event EventHandler? Connected;
+        
+        /// <summary>
+        /// Invoked when the SDK stops receiving data from iRacing.
+        /// </summary>
         public event EventHandler? Disconnected;
         #endregion
 

--- a/src/irsdkSharp/iRacingSDK.cs
+++ b/src/irsdkSharp/iRacingSDK.cs
@@ -23,6 +23,8 @@ namespace irsdkSharp
         private readonly ILogger<IRacingSDK>? _logger;
         
         private MemoryMappedFile? _iRacingFile;
+        private Dictionary<string, VarHeader>? _varHeaders;
+        
         private bool _isStarted = false;
 
         // TODO: Change to only use one CTS
@@ -37,7 +39,7 @@ namespace irsdkSharp
         #region Properties
         public IRacingSdkHeader? Header { get; private set; }
         public MemoryMappedViewAccessor? FileMapView { get; protected set; }
-        public Dictionary<string, VarHeader>? VarHeaders { get; protected set; }
+        public Dictionary<string, VarHeader>? VarHeaders => _varHeaders ??= Header?.GetVarHeaders(_encoding);
         #endregion
 
         #region Events
@@ -99,7 +101,6 @@ namespace irsdkSharp
             FileMapView = accessor;
 
             Header = new IRacingSdkHeader(FileMapView);
-            VarHeaders = Header.GetVarHeaders(_encoding);
             _isStarted = true;
         }
 
@@ -131,7 +132,7 @@ namespace irsdkSharp
                 {
                     _isStarted = false;
                     Header = null;
-                    VarHeaders = null;
+                    _varHeaders = null;
                     _logger?.LogDebug($"Not Connected {ex.Message}");
                 }
                 finally
@@ -160,10 +161,6 @@ namespace irsdkSharp
                                 Header = new IRacingSdkHeader(FileMapView);
                                 Connected?.Invoke(this, EventArgs.Empty);
                             }
-                            if (VarHeaders == null)
-                            { 
-                                VarHeaders = Header.GetVarHeaders(_encoding);
-                            }
                             DataChanged?.Invoke(this, EventArgs.Empty);
                         }
                         else
@@ -175,7 +172,7 @@ namespace irsdkSharp
                             }
                             if (VarHeaders != null)
                             {
-                                VarHeaders = null;
+                                _varHeaders = null;
                             }
                         }
                     }

--- a/src/irsdkSharp/iRacingSDK.cs
+++ b/src/irsdkSharp/iRacingSDK.cs
@@ -299,26 +299,25 @@ namespace irsdkSharp
 
             int varOffset = requestedHeader.Offset;
             int count = requestedHeader.Count;
+            int position = Header.Offset + varOffset;
 
             switch (requestedHeader.Type)
             {
                 case VarType.irChar:
                     {
                         byte[] data = new byte[count];
-                        FileMapView.ReadArray(Header.Offset + varOffset, data, 0, count);
+                        FileMapView.ReadArray(position, data, 0, count);
                         return _encoding.GetString(data).TrimEnd(Constants.EndChar);
                     }
                 case VarType.irBool:
                     {
                         if (count > 1)
                         {
-                            bool[] data = new bool[count];
-                            FileMapView.ReadArray(Header.Offset + varOffset, data, 0, count);
-                            return data;
+                            return FileMapView.ReadArray<bool>(position, count);
                         }
                         else
                         {
-                            return FileMapView.ReadBoolean(Header.Offset + varOffset);
+                            return FileMapView.ReadBoolean(position);
                         }
                     }
                 case VarType.irInt:
@@ -326,39 +325,33 @@ namespace irsdkSharp
                     {
                         if (count > 1)
                         {
-                            int[] data = new int[count];
-                            FileMapView.ReadArray(Header.Offset + varOffset, data, 0, count);
-                            return data;
+                            return FileMapView.ReadArray<int>(position, count);
                         }
                         else
                         {
-                            return FileMapView.ReadInt32(Header.Offset + varOffset);
+                            return FileMapView.ReadInt32(position);
                         }
                     }
                 case VarType.irFloat:
                     {
                         if (count > 1)
                         {
-                            float[] data = new float[count];
-                            FileMapView.ReadArray(Header.Offset + varOffset, data, 0, count);
-                            return data;
+                            return FileMapView.ReadArray<float>(position, count);
                         }
                         else
                         {
-                            return FileMapView.ReadSingle(Header.Offset + varOffset);
+                            return FileMapView.ReadSingle(position);
                         }
                     }
                 case VarType.irDouble:
                     {
                         if (count > 1)
                         {
-                            double[] data = new double[count];
-                            FileMapView.ReadArray(Header.Offset + varOffset, data, 0, count);
-                            return data;
+                            return FileMapView.ReadArray<double>(position, count);
                         }
                         else
                         {
-                            return FileMapView.ReadDouble(Header.Offset + varOffset);
+                            return FileMapView.ReadDouble(position);
                         }
                     }
                 default: return null;

--- a/src/irsdkSharp/iRacingSDK.cs
+++ b/src/irsdkSharp/iRacingSDK.cs
@@ -72,12 +72,17 @@ namespace irsdkSharp
         public static Dictionary<string, VarHeader> GetVarHeaders(IRacingSDK racingSDK)
             => racingSDK.VarHeaders;
 
-        public IRacingSDK()
+        public IRacingSDK(ILogger<IRacingSDK>? logger)
         {
             // Register CP1252 encoding
             Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
             _encoding = Encoding.GetEncoding(1252);
-
+            
+            _logger = logger;
+        }
+        
+        public IRacingSDK() : this(logger: null)
+        {
             _waitValidDataLoopCancellation = new CancellationTokenSource();
             _waitValidDataLoopCancellationToken = _waitValidDataLoopCancellation.Token;
             Task.Run(WaitValidDataLoop, _waitValidDataLoopCancellationToken);
@@ -87,17 +92,8 @@ namespace irsdkSharp
             Task.Run(ConnectionLoop, _waitValidDataLoopCancellationToken);
         }
 
-        public IRacingSDK(ILogger<IRacingSDK> logger) : this()
+        public IRacingSDK(MemoryMappedViewAccessor accessor) : this(logger: null)
         {
-            _logger = logger;
-        }
-
-        public IRacingSDK(MemoryMappedViewAccessor accessor)
-        {
-            // Register CP1252 encoding
-            Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
-            _encoding = Encoding.GetEncoding(1252);
-
             FileMapView = accessor;
 
             Header = new IRacingSdkHeader(FileMapView);

--- a/src/irsdkSharp/iRacingSDK.cs
+++ b/src/irsdkSharp/iRacingSDK.cs
@@ -28,24 +28,26 @@ namespace irsdkSharp
 
         #region Fields
         private readonly Encoding _encoding;
+        private readonly ILogger<IRacingSDK>? _logger;
 
         private bool IsStarted = false;
 
         MemoryMappedFile iRacingFile;
-        
-        protected MemoryMappedViewAccessor FileMapView;
-        protected Dictionary<string, VarHeader> VarHeaders;
-        
-        public IRacingSdkHeader Header = null;
 
+        // TODO: Change to only use one CTS
         private AutoResetEvent _gameLoopEvent;
         private IntPtr _hEvent;
-        private readonly ILogger<IRacingSDK> _logger;
         private readonly CancellationTokenSource _waitValidDataLoopCancellation;
         private readonly CancellationToken _waitValidDataLoopCancellationToken;
-        
         private readonly CancellationTokenSource _connectionLoopCancellation;
         private readonly CancellationToken _connectionLoopCancellationToken;
+        #endregion
+
+        #region Properties
+        public IRacingSdkHeader? Header { get; private set; } = null;
+        
+        public MemoryMappedViewAccessor FileMapView { get; protected set; }
+        public Dictionary<string, VarHeader> VarHeaders { get; protected set; }
         #endregion
 
         #region Events
@@ -54,15 +56,13 @@ namespace irsdkSharp
         public event Action OnDisconnected;
         #endregion
 
-        public static MemoryMappedViewAccessor GetFileMapView(IRacingSDK racingSDK)
-        {
-            return racingSDK.FileMapView;
-        }
+        [Obsolete("Use the getter of FileMapView instead.")]
+        public static MemoryMappedViewAccessor GetFileMapView(IRacingSDK racingSDK) 
+            => racingSDK.FileMapView;
 
+        [Obsolete("Use the getter of VarHeaders instead.")]
         public static Dictionary<string, VarHeader> GetVarHeaders(IRacingSDK racingSDK)
-        {
-            return racingSDK.VarHeaders;
-        }
+            => racingSDK.VarHeaders;
 
         public IRacingSDK()
         {

--- a/src/irsdkSharp/irsdkSharp.csproj
+++ b/src/irsdkSharp/irsdkSharp.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <LangVersion>9.0</LangVersion>
+    <LangVersion>11</LangVersion>
 	<TargetFrameworks>net6.0</TargetFrameworks>
     <PackageId>irsdkSharp</PackageId>
     <VersionPrefix>0.9.0</VersionPrefix>
@@ -19,14 +19,17 @@
     <TargetsForTfmSpecificBuildOutput>$(TargetsForTfmSpecificBuildOutput);CopyProjectReferencesToPackage</TargetsForTfmSpecificBuildOutput>
     <AssemblyName>irsdkSharp</AssemblyName>
     <RootNamespace>irsdkSharp</RootNamespace>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <DocumentationFile>bin\Debug\irsdkSharp.xml</DocumentationFile>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <DocumentationFile>bin\Release\irsdkSharp.xml</DocumentationFile>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|netstandard2.1|AnyCPU'">


### PR DESCRIPTION
### Improvements

- Only uses one loop to check the connection and update data
- Instantly cancel the `Task.Delay()` when the CancellationToken is cancelled (instead of waiting for the `Thread.Sleep()`)
- Added `IRacingSdkOptions` to set the `UpdateFrequency` and `CheckConnectionDelay`
- Optional `bool autoStart = true` parameter to the constructor instead of force start
- Added `Start()` method
- Added `Stop()` method
- Implemented `IDisposable`

### Possible breaking changes

- You wont be able to set `VarHeaders` via the protected setter
- You can only set `Header` privately now
- Renamed events and their sigature to close #54 