### PR TITLE
Debug.WriteLine in place of Console.WriteLine

### DIFF
--- a/src/irsdkSharp.Serialization/Models/Session/IRacingSessionModel.cs
+++ b/src/irsdkSharp.Serialization/Models/Session/IRacingSessionModel.cs
@@ -6,6 +6,7 @@ using irsdkSharp.Serialization.Models.Session.SessionInfo;
 using irsdkSharp.Serialization.Models.Session.SplitTimeInfo;
 using irsdkSharp.Serialization.Models.Session.WeekendInfo;
 using System;
+using System.Diagnostics;
 using System.IO;
 using YamlDotNet.Serialization;
 
@@ -23,8 +24,8 @@ namespace irsdkSharp.Serialization.Models.Session
             }
             catch(Exception ex)
             {
-                Console.WriteLine(ex.Message);
-                Console.WriteLine(ex.StackTrace);
+                Debug.WriteLine(ex.Message);
+                Debug.WriteLine(ex.StackTrace);
                 return null;
             }
         }


### PR DESCRIPTION
Hello,

I'm using this library in a project which is communicating via CGI with a nodejs project. The latter takes the console output of the C# project in a json format. My problem is that when the iRacing yaml fail to parse via the YamlParser, the error is sent to the standard output via the `Console.WriteLine` which pollute the output and any client connected to the app fails to parse as it's not JSON.

As it is an error message and a stack trace, I propose to write them in the Debug trace listeners instead, that way we can still see them in a debug env.